### PR TITLE
fix: allow OpenAI client mocking in tests

### DIFF
--- a/src/app/ocr_bridge.py
+++ b/src/app/ocr_bridge.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import base64
 import cv2
-from openai import OpenAI
+import openai
 from .core.config import settings
 
 class BaseOCR(ABC):
@@ -28,7 +28,7 @@ class DummyOCR(BaseOCR):
 class GPT4oMiniVisionOCR(BaseOCR):
     """GPT-4o mini を利用したOCRエンジン"""
     def __init__(self):
-        self.client = OpenAI(api_key=settings.OPENAI_API_KEY)
+        self.client = openai.OpenAI(api_key=settings.OPENAI_API_KEY)
 
     def run(self, image: np.ndarray) -> tuple[str, float]:
         # 画像をBase64にエンコード


### PR DESCRIPTION
## Summary
- import `openai` module directly so `openai.OpenAI` can be mocked
- update GPT4oMiniVisionOCR to instantiate client via `openai.OpenAI`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7d17be6c83338d90ab6292e2bc50