### PR TITLE
Add .gitignore for Python caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.vscode/
+.idea/
+*.swp
+*~
+.DS_Store


### PR DESCRIPTION
## Summary
- add repo-level `.gitignore` to exclude common Python build artifacts and IDE files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c051957ec83339690d3f68378dd11