### PR TITLE
Switch OCR model to gpt-4.1-mini

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -21,7 +21,7 @@ st.title("AIOCR処理実行")
 st.sidebar.title("設定")
 ocr_engine_choice = st.sidebar.selectbox(
     "OCRエンジンを選択",
-    ("DummyOCR", "GPT-4o-mini")
+    ("DummyOCR", "GPT-4.1-mini")
 )
 
 # --- メイン画面 --- 
@@ -106,7 +106,7 @@ if uploaded_image is not None and (uploaded_yaml is not None or template_option 
 
             # 6. 選択されたOCRエンジンで処理を実行
             st.write(f"{ocr_engine_choice} でOCR処理を実行しています...")
-            if ocr_engine_choice == "GPT-4o-mini":
+            if ocr_engine_choice == "GPT-4.1-mini":
                 ocr_engine = GPT4oMiniVisionOCR()
             else:
                 ocr_engine = DummyOCR()

--- a/src/app/ocr_bridge.py
+++ b/src/app/ocr_bridge.py
@@ -37,7 +37,7 @@ class GPT4oMiniVisionOCR(BaseOCR):
 
         try:
             response = self.client.chat.completions.create(
-                model="gpt-4o-mini",
+                model="gpt-4.1-mini",
                 messages=[
                     {
                         "role": "user",

--- a/tests/test_ocr_bridge.py
+++ b/tests/test_ocr_bridge.py
@@ -67,4 +67,4 @@ def test_gpt4o_mini_vision_ocr_mocked(MockOpenAI, sample_text_image):
     # APIが正しい引数で呼び出されたか確認
     mock_client.chat.completions.create.assert_called_once()
     call_args = mock_client.chat.completions.create.call_args
-    assert call_args.kwargs['model'] == "gpt-4o-mini"
+    assert call_args.kwargs['model'] == "gpt-4.1-mini"


### PR DESCRIPTION
## Summary
- update main app and OCR bridge to use `gpt-4.1-mini`
- adjust unit tests for new model string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c973877648333844c9ec96cefbb10