### PR TITLE
refactor(core): introduce OcrAgent for centralized OCR workflow

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,22 +1,19 @@
 
 import streamlit as st
 import os
-import cv2
-import json
-import numpy as np
-from datetime import datetime
+import sys
 from typing import Dict, List
 
-import sys
+import cv2
+import numpy as np
 
 # Ensure src directory is on the import path when executed directly
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app import preprocess
 from app.ocr_bridge import DummyOCR, GPT4oMiniVisionOCR
-from app.ocr_processor import OCRProcessor
 from core.template_manager import TemplateManager
 from core.db_manager import DBManager
+from core.ocr_agent import OcrAgent
 
 # テンプレート名と検出キーワードの対応表
 TEMPLATE_KEYWORDS: Dict[str, List[str]] = {
@@ -50,14 +47,7 @@ template_option = st.selectbox(
 if uploaded_image is not None and template_names:
     if st.button("OCR処理実行"):
         with st.spinner('AI-OCR処理を実行中です...'):
-            # 2. ユニークな作業ディレクトリを作成
-            now = datetime.now()
-            doc_id = f"DOC_{now.strftime('%Y%m%d_%H%M%S')}"
-            workspace_dir = os.path.join("workspace", doc_id)
-            crops_dir = os.path.join(workspace_dir, "crops")
-            os.makedirs(crops_dir, exist_ok=True)
-
-            # 3. 画像を読み込み、必要ならテンプレートを自動検出
+            # 画像を読み込み、必要ならテンプレートを自動検出
             file_bytes = np.asarray(bytearray(uploaded_image.read()), dtype=np.uint8)
             image = cv2.imdecode(file_bytes, 1)
 
@@ -81,54 +71,25 @@ if uploaded_image is not None and template_names:
             else:
                 template_data = template_manager.load(template_option)
 
-            selected_template = template_data.get("name", template_option)
-            rois = template_data.get("rois", {})
-
-            template_json_path = os.path.join(workspace_dir, "template.json")
-            with open(template_json_path, "w", encoding="utf-8") as f:
-                json.dump(template_data, f, ensure_ascii=False, indent=2)
-
-            # 4. 傾き補正を行う
-            
-            st.write("画像の傾きを補正しています...")
-            corrected_image = preprocess.correct_skew(image)
-            
-            # 5. テンプレートの定義に従ってROIを切り出し、保存
-            st.write("ROIを切り出しています...")
-            for i, (key, roi_info) in enumerate(rois.items()):
-                roi_box = roi_info['box']
-                cropped_img = preprocess.crop_roi(corrected_image, roi_box)
-                
-                filename = f"P{i+1}_{key}.png"
-                save_path = os.path.join(crops_dir, filename)
-                cv2.imwrite(save_path, cropped_img)
-
-            # 6. 選択されたOCRエンジンで処理を実行
+            # OCRエンジンを選択
             st.write(f"{ocr_engine_choice} でOCR処理を実行しています...")
             if ocr_engine_choice == "GPT-4.1-mini":
                 ocr_engine = GPT4oMiniVisionOCR()
             else:
                 ocr_engine = DummyOCR()
-            
-            processor = OCRProcessor(ocr_engine, workspace_dir, rois=rois)
-            ocr_results = processor.process_all()
 
             db = DBManager()
             db.initialize()
-            job_id = db.create_job(selected_template, now.isoformat())
-            for roi_name, info in ocr_results.items():
-                status = "needs_human" if info.get("needs_human") else "ok"
-                db.add_result(
-                    job_id,
-                    uploaded_image.name,
-                    roi_name,
-                    final_text=info["text"],
-                    confidence_score=info["confidence"],
-                    status=status,
-                )
+            agent = OcrAgent(db=db, templates=template_manager)
+            ocr_results, workspace_dir = agent.process_document(
+                image,
+                uploaded_image.name,
+                template_data,
+                ocr_engine,
+            )
             db.close()
 
-        # 7. 処理完了メッセージと結果を表示
+        # 処理完了メッセージと結果を表示
         st.success("処理が完了しました！")
         st.info(f"作業ディレクトリ: {os.path.abspath(workspace_dir)}")
 

--- a/tests/test_ocr_agent.py
+++ b/tests/test_ocr_agent.py
@@ -1,0 +1,37 @@
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from core.db_manager import DBManager
+from core.template_manager import TemplateManager
+from core.ocr_agent import OcrAgent
+from app.ocr_bridge import DummyOCR
+
+
+def test_ocr_agent_process_document(tmp_path):
+    # change working directory to temporary path to avoid polluting repo
+    os.chdir(tmp_path)
+
+    db_path = tmp_path / "ocr.db"
+    db = DBManager(str(db_path))
+    db.initialize()
+
+    templates = TemplateManager(template_dir=str(tmp_path / "templates"))
+    agent = OcrAgent(db=db, templates=templates)
+
+    # create dummy image
+    image = np.zeros((20, 20, 3), dtype=np.uint8)
+
+    template_data = {"name": "test", "rois": {"field": {"box": [0, 0, 10, 10]}}}
+
+    results, workspace = agent.process_document(
+        image, "test.png", template_data, DummyOCR()
+    )
+
+    assert "field" in results
+    assert Path(workspace).exists()
+    db_results = db.fetch_results(1)
+    assert db_results[0]["roi_name"] == "field"
+    db.close()


### PR DESCRIPTION
## Summary
- centralize preprocessing, OCR, and result persistence in new `OcrAgent`
- streamline Streamlit entry point to delegate processing to the agent
- add tests for OcrAgent document processing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d934272a08333b5b1d51f295e037b