### PR TITLE
feat: add double check OCR

### DIFF
--- a/tests/test_ocr_agent.py
+++ b/tests/test_ocr_agent.py
@@ -27,11 +27,15 @@ def test_ocr_agent_process_document(tmp_path):
     template_data = {"name": "test", "rois": {"field": {"box": [0, 0, 10, 10]}}}
 
     results, workspace = agent.process_document(
-        image, "test.png", template_data, DummyOCR()
+        image, "test.png", template_data, DummyOCR(), DummyOCR()
     )
 
     assert "field" in results
     assert Path(workspace).exists()
     db_results = db.fetch_results(1)
     assert db_results[0]["roi_name"] == "field"
+    assert db_results[0]["text_mini"] == "ダミーテキスト(10x10)"
+    assert db_results[0]["text_nano"] == "ダミーテキスト(10x10)"
+    assert db_results[0]["confidence_score"] == 1.0
+    assert db_results[0]["status"] == "high"
     db.close()


### PR DESCRIPTION
## Summary
- implement GPT-4o nano OCR engine
- run primary and validator OCR engines for double-check
- persist mini/nano texts and confidence level in DB and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d956d864083339ca570348024c441