### PR TITLE
feat(preprocess): align rois with template-based transform

### DIFF
--- a/src/core/preprocess.py
+++ b/src/core/preprocess.py
@@ -48,3 +48,70 @@ def crop_roi(image: np.ndarray, roi_box: list[int]) -> np.ndarray:
     """
     x, y, w, h = roi_box
     return image[y:y+h, x:x+w]
+
+
+def align_rois(
+    template: np.ndarray,
+    image: np.ndarray,
+    rois: dict[str, dict],
+) -> dict[str, dict]:
+    """Align ROI coordinates from template to the target image.
+
+    ORB特徴量でテンプレート画像と入力画像をマッチングし、
+    アフィン変換を推定してROI座標を補正します。
+
+    Parameters
+    ----------
+    template:
+        Reference template image.
+    image:
+        Target image to be aligned.
+    rois:
+        ROI定義を含む辞書。``{"name": {"box": [x, y, w, h]}}`` 形式。
+
+    Returns
+    -------
+    dict[str, dict]
+        補正後のROI辞書。
+    """
+
+    # ORBで特徴量を抽出
+    orb = cv2.ORB_create()
+    gray_t = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
+    gray_i = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    kp1, des1 = orb.detectAndCompute(gray_t, None)
+    kp2, des2 = orb.detectAndCompute(gray_i, None)
+
+    if des1 is None or des2 is None or len(kp1) < 3 or len(kp2) < 3:
+        return rois
+
+    # マッチング
+    bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+    matches = bf.match(des1, des2)
+    if len(matches) < 3:
+        return rois
+
+    matches = sorted(matches, key=lambda x: x.distance)[:50]
+    src_pts = np.float32([kp1[m.queryIdx].pt for m in matches]).reshape(-1, 1, 2)
+    dst_pts = np.float32([kp2[m.trainIdx].pt for m in matches]).reshape(-1, 1, 2)
+
+    M, _ = cv2.estimateAffinePartial2D(src_pts, dst_pts)
+    if M is None:
+        return rois
+
+    aligned = {}
+    for key, info in rois.items():
+        x, y, w, h = info["box"]
+        corners = np.array(
+            [[x, y], [x + w, y], [x + w, y + h], [x, y + h]], dtype=np.float32
+        ).reshape(-1, 1, 2)
+        transformed = cv2.transform(corners, M)
+        xs = transformed[:, 0, 0]
+        ys = transformed[:, 0, 1]
+        new_x, new_y = xs.min(), ys.min()
+        new_w, new_h = xs.max() - new_x, ys.max() - new_y
+        updated = info.copy()
+        updated["box"] = [int(round(new_x)), int(round(new_y)), int(round(new_w)), int(round(new_h))]
+        aligned[key] = updated
+
+    return aligned

--- a/tests/test_roi_alignment.py
+++ b/tests/test_roi_alignment.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from core.db_manager import DBManager
+from core.template_manager import TemplateManager
+from core.ocr_agent import OcrAgent
+from core.ocr_bridge import DummyOCR
+from core import preprocess
+
+
+def test_roi_alignment_with_shift(tmp_path, monkeypatch):
+    os.chdir(tmp_path)
+
+    # avoid skew correction for this test
+    monkeypatch.setattr(preprocess, "correct_skew", lambda img: img)
+
+    # create template image with distinctive features
+    template_img = np.full((200, 200, 3), 255, dtype=np.uint8)
+    cv2.putText(template_img, "TEST", (40, 80), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 0), 2)
+    cv2.circle(template_img, (150, 150), 20, (0, 0, 0), -1)
+    template_path = tmp_path / "template.png"
+    cv2.imwrite(str(template_path), template_img)
+
+    # shift image
+    M = np.float32([[1, 0, 20], [0, 1, 10]])
+    shifted_img = cv2.warpAffine(template_img, M, (200, 200), borderValue=(255, 255, 255))
+
+    # prepare environment
+    db = DBManager(str(tmp_path / "ocr.db"))
+    db.initialize()
+    templates = TemplateManager(template_dir=str(tmp_path / "templates"))
+    agent = OcrAgent(db=db, templates=templates)
+
+    template_data = {
+        "name": "test",
+        "template_image": str(template_path),
+        "rois": {"field": {"box": [40, 60, 80, 40]}},
+    }
+
+    results, workspace = agent.process_document(
+        shifted_img, "shifted.png", template_data, DummyOCR(), DummyOCR()
+    )
+
+    crop_path = Path(workspace) / "crops" / "P1_field.png"
+    assert crop_path.exists()
+    cropped = cv2.imread(str(crop_path))
+    expected = shifted_img[70:110, 60:140]
+    assert np.array_equal(cropped, expected)
+    assert results["field"]["text"] == "ダミーテキスト(80x40)"
+    db.close()


### PR DESCRIPTION
## Summary
- compute affine transform with ORB feature matching to map template ROIs to target image
- adjust ROI cropping in `OcrAgent` using aligned coordinates
- add test ensuring ROI extraction is correct for shifted images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d9e84be8883339f802b95d91d5ca2