### PR TITLE
feat: process multiple images per job

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -3,6 +3,7 @@ import streamlit as st
 import os
 import sys
 from typing import Dict, List
+from datetime import datetime
 
 import cv2
 import numpy as np
@@ -32,8 +33,10 @@ ocr_engine_choice = st.sidebar.selectbox(
 # --- メイン画面 --- 
 
 # 1. ファイルアップローダー
-uploaded_image = st.file_uploader(
-    "画像ファイルをアップロードしてください", type=["png", "jpg", "jpeg"]
+uploaded_images = st.file_uploader(
+    "画像ファイルをアップロードしてください",
+    type=["png", "jpg", "jpeg"],
+    accept_multiple_files=True,
 )
 
 # テンプレート選択肢を準備
@@ -44,65 +47,83 @@ template_option = st.selectbox(
     ["自動検出"] + template_names,
 )
 
-if uploaded_image is not None and template_names:
+if uploaded_images and template_names:
     if st.button("OCR処理実行"):
+        db = DBManager()
+        db.initialize()
+        job_id = db.create_job(template_option, datetime.now().isoformat())
+        agent = OcrAgent(db=db, templates=template_manager)
+
+        # OCRエンジンを選択
+        st.write(f"{ocr_engine_choice} でOCR処理を実行しています...")
+        if ocr_engine_choice == "GPT-4.1-mini":
+            ocr_engine = GPT4oMiniVisionOCR()
+        else:
+            ocr_engine = DummyOCR()
+        nano_engine = GPT4oNanoVisionOCR()
+
+        combined_results = {}
+        workspace_dirs = {}
+        progress = st.progress(0)
+        total = len(uploaded_images)
+
         with st.spinner('AI-OCR処理を実行中です (GPT-4.1-nanoでダブルチェック)...'):
-            # 画像を読み込み、必要ならテンプレートを自動検出
-            file_bytes = np.asarray(bytearray(uploaded_image.read()), dtype=np.uint8)
-            image = cv2.imdecode(file_bytes, 1)
+            static_template = None
+            if template_option != "自動検出":
+                static_template = template_manager.load(template_option)
 
-            if template_option == "自動検出":
-                st.write("テンプレートを自動検出しています...")
-                text, _ = DummyOCR().run(image)
-                best_template = None
-                best_score = 0
-                for tpl in template_names:
-                    keywords = TEMPLATE_KEYWORDS.get(tpl, [])
-                    score = sum(kw in text for kw in keywords)
-                    if score > best_score:
-                        best_score = score
-                        best_template = tpl
-                if best_template:
-                    st.info(f"自動検出結果: {best_template}")
-                    template_data = template_manager.load(best_template)
+            for idx, uploaded_image in enumerate(uploaded_images, start=1):
+                file_bytes = np.asarray(bytearray(uploaded_image.read()), dtype=np.uint8)
+                image = cv2.imdecode(file_bytes, 1)
+
+                if template_option == "自動検出":
+                    st.write(f"{uploaded_image.name} のテンプレートを自動検出しています...")
+                    text, _ = DummyOCR().run(image)
+                    best_template = None
+                    best_score = 0
+                    for tpl in template_names:
+                        keywords = TEMPLATE_KEYWORDS.get(tpl, [])
+                        score = sum(kw in text for kw in keywords)
+                        if score > best_score:
+                            best_score = score
+                            best_template = tpl
+                    if best_template:
+                        template_data = template_manager.load(best_template)
+                    else:
+                        st.warning("テンプレートを特定できなかったため、最初のテンプレートを使用します")
+                        template_data = template_manager.load(template_names[0])
                 else:
-                    st.warning("テンプレートを特定できなかったため、最初のテンプレートを使用します")
-                    template_data = template_manager.load(template_names[0])
-            else:
-                template_data = template_manager.load(template_option)
+                    template_data = static_template
 
-            # OCRエンジンを選択
-            st.write(f"{ocr_engine_choice} でOCR処理を実行しています...")
-            if ocr_engine_choice == "GPT-4.1-mini":
-                ocr_engine = GPT4oMiniVisionOCR()
-            else:
-                ocr_engine = DummyOCR()
+                ocr_results, workspace_dir = agent.process_document(
+                    image,
+                    uploaded_image.name,
+                    template_data,
+                    ocr_engine,
+                    validator_engine=nano_engine,
+                    job_id=job_id,
+                )
+                combined_results[uploaded_image.name] = ocr_results
+                workspace_dirs[uploaded_image.name] = workspace_dir
+                progress.progress(idx / total)
 
-            nano_engine = GPT4oNanoVisionOCR()
-
-            db = DBManager()
-            db.initialize()
-            agent = OcrAgent(db=db, templates=template_manager)
-            ocr_results, workspace_dir = agent.process_document(
-                image,
-                uploaded_image.name,
-                template_data,
-                ocr_engine,
-                validator_engine=nano_engine,
-            )
-            db.close()
+        db.close()
 
         # 処理完了メッセージと結果を表示
         st.success("処理が完了しました！")
-        st.info(f"作業ディレクトリ: {os.path.abspath(workspace_dir)}")
+        st.subheader("作業ディレクトリ")
+        for name, path in workspace_dirs.items():
+            st.write(f"{name}: {os.path.abspath(path)}")
 
         st.subheader("OCR抽出結果 (extract.json)")
-        st.json(ocr_results)
+        st.json(combined_results)
 
         st.subheader("信頼度とダブルチェック結果")
-        for field, info in ocr_results.items():
-            conf_score = info.get("confidence", 0.0)
-            level = info.get("confidence_level", "")
-            needs_human = info.get("needs_human", False)
-            icon = "✅" if not needs_human else "⚠️"
-            st.write(f"{icon} {field}: 信頼度 {conf_score:.2f} ({level})")
+        for img_name, ocr_result in combined_results.items():
+            st.markdown(f"### {img_name}")
+            for field, info in ocr_result.items():
+                conf_score = info.get("confidence", 0.0)
+                level = info.get("confidence_level", "")
+                needs_human = info.get("needs_human", False)
+                icon = "✅" if not needs_human else "⚠️"
+                st.write(f"{icon} {field}: 信頼度 {conf_score:.2f} ({level})")

--- a/tests/test_ocr_agent.py
+++ b/tests/test_ocr_agent.py
@@ -39,3 +39,33 @@ def test_ocr_agent_process_document(tmp_path):
     assert db_results[0]["confidence_score"] == 1.0
     assert db_results[0]["status"] == "high"
     db.close()
+
+
+def test_ocr_agent_multiple_images_single_job(tmp_path):
+    os.chdir(tmp_path)
+
+    db_path = tmp_path / "ocr.db"
+    db = DBManager(str(db_path))
+    db.initialize()
+
+    templates = TemplateManager(template_dir=str(tmp_path / "templates"))
+    agent = OcrAgent(db=db, templates=templates)
+
+    image = np.zeros((20, 20, 3), dtype=np.uint8)
+    template_data = {"name": "test", "rois": {"field": {"box": [0, 0, 10, 10]}}}
+
+    job_id = db.create_job("test", "2025-01-01T00:00:00")
+    for name in ["a.png", "b.png"]:
+        agent.process_document(
+            image,
+            name,
+            template_data,
+            DummyOCR(),
+            DummyOCR(),
+            job_id=job_id,
+        )
+
+    db_results = db.fetch_results(job_id)
+    assert len(db_results) == 2
+    assert {r["image_name"] for r in db_results} == {"a.png", "b.png"}
+    db.close()


### PR DESCRIPTION
## Summary
- allow uploading and processing multiple images at once with a progress bar
- support associating multiple images to a single database job
- test multi-image jobs in OCR agent

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688da6526bac833399fff515c8d08513