### PR TITLE
refactor: cache app resources

### DIFF
--- a/src/app/0_Template_Editor.py
+++ b/src/app/0_Template_Editor.py
@@ -8,7 +8,7 @@ from PIL import Image
 import streamlit as st
 from streamlit_drawable_canvas import st_canvas
 
-from core.template_manager import TemplateManager
+from app.cache_utils import get_template_manager, list_templates
 
 
 NEW_TEMPLATE = "新規作成"
@@ -36,8 +36,8 @@ def _load_initial_drawing(rois: Dict[str, Dict[str, List[int]]]) -> Dict[str, Li
 def main() -> None:
     st.title("Template Editor")
 
-    manager = TemplateManager()
-    templates = manager.list_templates()
+    manager = get_template_manager()
+    templates = list_templates()
 
     selection = st.selectbox("テンプレートを選択", [NEW_TEMPLATE] + templates)
     template_name = st.text_input("テンプレート名", value="" if selection == NEW_TEMPLATE else selection)
@@ -104,6 +104,7 @@ def main() -> None:
         else:
             data = {"name": template_name, "rois": roi_definitions, "corrections": {}}
             manager.save(template_name, data)
+            list_templates.clear()
             st.success("テンプレートを保存しました。")
 
 

--- a/src/app/cache_utils.py
+++ b/src/app/cache_utils.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Caching helpers for Streamlit apps.
+
+This module provides cached constructors for commonly used resources such
+as :class:`TemplateManager` and :class:`DBManager`.  Using Streamlit's caching
+primitives avoids repeated disk access for templates and keeps a single
+SQLite connection alive throughout a session.
+"""
+
+import streamlit as st
+
+from core.template_manager import TemplateManager
+from core.db_manager import DBManager
+
+
+@st.cache_resource
+def get_template_manager() -> TemplateManager:
+    """Return a cached :class:`TemplateManager` instance."""
+    return TemplateManager()
+
+
+@st.cache_resource
+def get_db_manager() -> DBManager:
+    """Return an initialised and cached :class:`DBManager` instance."""
+    db = DBManager()
+    db.initialize()
+    return db
+
+
+@st.cache_data
+def list_templates() -> list[str]:
+    """Return available template names with data caching."""
+    return get_template_manager().list_templates()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -12,8 +12,8 @@ import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.ocr_bridge import DummyOCR, GPT4oMiniVisionOCR, GPT4oNanoVisionOCR
-from core.template_manager import TemplateManager
-from core.db_manager import DBManager
+# Caching helpers
+from app.cache_utils import get_template_manager, get_db_manager, list_templates
 from core.ocr_agent import OcrAgent
 
 # テンプレート名と検出キーワードの対応表
@@ -40,8 +40,8 @@ uploaded_images = st.file_uploader(
 )
 
 # テンプレート選択肢を準備
-template_manager = TemplateManager()
-template_names = template_manager.list_templates()
+template_manager = get_template_manager()
+template_names = list_templates()
 template_option = st.selectbox(
     "帳票テンプレートを選択",
     ["自動検出"] + template_names,
@@ -49,8 +49,7 @@ template_option = st.selectbox(
 
 if uploaded_images and template_names:
     if st.button("OCR処理実行"):
-        db = DBManager()
-        db.initialize()
+        db = get_db_manager()
         job_id = db.create_job(template_option, datetime.now().isoformat())
         agent = OcrAgent(db=db, templates=template_manager)
 
@@ -106,8 +105,6 @@ if uploaded_images and template_names:
                 combined_results[uploaded_image.name] = ocr_results
                 workspace_dirs[uploaded_image.name] = workspace_dir
                 progress.progress(idx / total)
-
-        db.close()
 
         # 処理完了メッセージと結果を表示
         st.success("処理が完了しました！")

--- a/src/app/pages/1_Review.py
+++ b/src/app/pages/1_Review.py
@@ -2,8 +2,7 @@ import os
 import json
 import streamlit as st
 
-from core.db_manager import DBManager
-from core.template_manager import TemplateManager
+from app.cache_utils import get_db_manager, get_template_manager
 
 st.title("レビュー")
 
@@ -17,11 +16,8 @@ def save_correction(item: dict, new_text: str, add_dict: bool) -> None:
     with open(item["extract_path"], "w", encoding="utf-8") as f:
         json.dump(item["data"], f, ensure_ascii=False, indent=4)
 
-    db = DBManager()
-    try:
-        db.update_result_by_text(item["key"], item["text"], new_text)
-    finally:
-        db.close()
+    db = get_db_manager()
+    db.update_result_by_text(item["key"], item["text"], new_text)
     st.info("DBを更新しました")
 
     corrections_path = os.path.join(WORKSPACE_DIR, "corrections.jsonl")
@@ -35,7 +31,7 @@ def save_correction(item: dict, new_text: str, add_dict: bool) -> None:
             with open(template_json, "r", encoding="utf-8") as tf:
                 tdata = json.load(tf)
             template_name = tdata.get("name")
-            tm = TemplateManager()
+            tm = get_template_manager()
             tm.append_correction(template_name, item["text"], new_text)
             st.info("テンプレートを更新しました")
         except Exception:

--- a/src/app/pages/2_Dashboard.py
+++ b/src/app/pages/2_Dashboard.py
@@ -2,10 +2,16 @@ import streamlit as st
 import pandas as pd
 from core.dashboard_utils import compute_metrics
 
+
+@st.cache_data
+def load_metrics():
+    """Compute and cache dashboard metrics."""
+    return compute_metrics("workspace")
+
 st.title("パフォーマンス・ダッシュボード")
 
 if 'metrics' not in st.session_state or st.button("更新"):
-    st.session_state['metrics'] = compute_metrics("workspace")
+    st.session_state['metrics'] = load_metrics()
 
 total_docs, total_fields, auto_rate, daily_df = st.session_state['metrics']
 


### PR DESCRIPTION
## Summary
- cache TemplateManager and DBManager with Streamlit helpers
- use cached resources across app modules and clear template cache after saving
- cache dashboard metrics for faster reloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688db800a1d48333af7290069de796ba