### PR TITLE
fix: use nano OCR for template detection

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,4 +1,5 @@
 
+import asyncio
 import streamlit as st
 import os
 import sys
@@ -77,7 +78,7 @@ if uploaded_images and template_names:
 
                 if template_option == "自動検出":
                     st.write(f"{uploaded_image.name} のテンプレートを自動検出しています...")
-                    text, _ = DummyOCR().run(image)
+                    text, _ = asyncio.run(GPT4oNanoVisionOCR().run(image))
                     best_template = None
                     best_score = 0
                     for tpl in template_names:


### PR DESCRIPTION
## Summary
- import asyncio
- use GPT4oNanoVisionOCR via asyncio.run for auto template detection instead of DummyOCR

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dde534df88333bcd8e35bd7cb2554