### PR TITLE
fix: update template editor corrections storage

### DIFF
--- a/src/app/0_Template_Editor.py
+++ b/src/app/0_Template_Editor.py
@@ -102,7 +102,7 @@ def main() -> None:
         elif not roi_definitions:
             st.error("ROIを少なくとも1つ描画してください。")
         else:
-            data = {"name": template_name, "rois": roi_definitions, "corrections": {}}
+            data = {"name": template_name, "rois": roi_definitions, "corrections": []}
             manager.save(template_name, data)
             list_templates.clear()
             st.success("テンプレートを保存しました。")


### PR DESCRIPTION
## Summary
- save template corrections as a list instead of a dict

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688de0d9320483338c4ccc49f72c6009