### PR TITLE
refactor: isolate OCR processing in 1_Main_OCR

### DIFF
--- a/src/app/1_Main_OCR.py
+++ b/src/app/1_Main_OCR.py
@@ -23,6 +23,7 @@ TEMPLATE_KEYWORDS: Dict[str, List[str]] = {
 
 
 def main() -> None:
+    st.set_page_config(page_title="AIOCR")
     st.title("AIOCR処理実行")
 
     # --- サイドバー ---

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -8,8 +8,6 @@ import streamlit as st
 
 def main() -> None:
     """Redirect to the main OCR page while exposing navigation links."""
-    st.set_page_config(page_title="AIOCR")
-
     st.sidebar.page_link("1_Main_OCR.py", label="Main OCR")
     st.sidebar.page_link("pages/1_Review.py", label="Review")
     st.sidebar.page_link("pages/2_Dashboard.py", label="Dashboard")


### PR DESCRIPTION
## Summary
- move page configuration and OCR handling from `main.py` into dedicated `1_Main_OCR.py`
- simplify `main.py` to navigation only entry point redirecting to `1_Main_OCR`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688de543890c8333b9d12c0bf82426ce