### PR TITLE
feat(template): add keyword support

### DIFF
--- a/src/app/0_Template_Editor.py
+++ b/src/app/0_Template_Editor.py
@@ -43,14 +43,21 @@ def main() -> None:
     template_name = st.text_input("テンプレート名", value="" if selection == NEW_TEMPLATE else selection)
 
     existing_rois: Dict[str, Dict[str, List[int]]] = {}
+    existing_keywords: List[str] = []
     if selection != NEW_TEMPLATE:
         try:
             existing = manager.load(selection)
             existing_rois = existing.get("rois", {})
+            existing_keywords = existing.get("keywords", [])
         except FileNotFoundError:
             st.warning("テンプレートが見つかりません。")
 
     uploaded = st.file_uploader("基準画像をアップロード", type=["png", "jpg", "jpeg"])
+
+    keywords_text = st.text_input(
+        "キーワード (カンマ区切り)",
+        value=", ".join(existing_keywords),
+    )
 
     if uploaded is None:
         st.info("画像をアップロードしてください。")
@@ -102,8 +109,12 @@ def main() -> None:
         elif not roi_definitions:
             st.error("ROIを少なくとも1つ描画してください。")
         else:
+            keywords = [
+                kw.strip() for kw in keywords_text.split(",") if kw.strip()
+            ]
             data = {
                 "name": template_name,
+                "keywords": keywords,
                 "rois": roi_definitions,
                 # corrections are stored as a list for forward compatibility
                 "corrections": [],

--- a/src/app/1_Main_OCR.py
+++ b/src/app/1_Main_OCR.py
@@ -16,10 +16,8 @@ from app.cache_utils import get_template_manager, get_db_manager, list_templates
 from core.ocr_agent import OcrAgent
 
 
-# テンプレート名と検出キーワードの対応表
-TEMPLATE_KEYWORDS: Dict[str, List[str]] = {
-    "invoice": ["請求", "請求書", "御中"],
-}
+# テンプレート名と検出キーワードはテンプレートファイル内で管理
+# TemplateManager を通じて読み込む
 
 
 def main() -> None:
@@ -49,6 +47,9 @@ def main() -> None:
     # テンプレート選択肢を準備
     template_manager = get_template_manager()
     template_names = list_templates()
+    template_keywords: Dict[str, List[str]] = {
+        name: template_manager.get_keywords(name) for name in template_names
+    }
     template_option = st.selectbox(
         "帳票テンプレートを選択",
         ["自動検出"] + template_names,
@@ -88,7 +89,7 @@ def main() -> None:
                         best_template = None
                         best_score = 0
                         for tpl in template_names:
-                            keywords = TEMPLATE_KEYWORDS.get(tpl, [])
+                            keywords = template_keywords.get(tpl, [])
                             score = sum(kw in text for kw in keywords)
                             if score > best_score:
                                 best_score = score

--- a/src/core/template_manager.py
+++ b/src/core/template_manager.py
@@ -33,10 +33,23 @@ class TemplateManager:
             return json.load(f)
 
     def save(self, name: str, data: Dict[str, Any]) -> None:
-        """Save template data to a JSON file."""
+        """Save template data to a JSON file.
+
+        The ``keywords`` field is normalised to always be present as a list to
+        simplify downstream consumption."""
         path = self.template_dir / f"{name}.json"
+        data.setdefault("keywords", [])
         with path.open("w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
+
+    def get_keywords(self, name: str) -> List[str]:
+        """Return the list of detection keywords for a template.
+
+        If the template does not define any keywords an empty list is
+        returned."""
+        data = self.load(name)
+        keywords = data.get("keywords", [])
+        return keywords if isinstance(keywords, list) else []
 
     def append_correction(self, name: str, wrong: str, correct: str) -> None:
         """Append a correction pair to template's correction list.

--- a/templates/invoice.json
+++ b/templates/invoice.json
@@ -1,5 +1,6 @@
 {
   "name": "invoice",
+  "keywords": ["請求", "請求書", "御中"],
   "rois": {
     "zip_code": {
       "box": [100, 150, 120, 50],

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -3,9 +3,14 @@ from core.template_manager import TemplateManager
 
 def test_template_manager_roundtrip(tmp_path):
     manager = TemplateManager(template_dir=str(tmp_path))
-    data = {"name": "tmp", "rois": {"field": {"box": [0, 0, 10, 10]}}}
+    data = {
+        "name": "tmp",
+        "keywords": ["a", "b"],
+        "rois": {"field": {"box": [0, 0, 10, 10]}},
+    }
     manager.save("sample", data)
 
     assert manager.list_templates() == ["sample"]
+    assert manager.get_keywords("sample") == ["a", "b"]
     loaded = manager.load("sample")
     assert loaded == data


### PR DESCRIPTION
## Summary
- extend template format with `keywords` list for automatic detection
- load keywords through `TemplateManager` and use them in OCR auto-selection
- allow editing template keywords via Template Editor UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688de671360c8333bcc07664128f340d