### PR TITLE
feat: update results by identifier

### DIFF
--- a/src/app/pages/1_Review.py
+++ b/src/app/pages/1_Review.py
@@ -17,7 +17,7 @@ def save_correction(item: dict, new_text: str, add_dict: bool) -> None:
         json.dump(item["data"], f, ensure_ascii=False, indent=4)
 
     db = get_db_manager()
-    db.update_result_by_text(item["key"], item["text"], new_text)
+    db.update_result_by_text(item["result_id"], item["key"], item["text"], new_text)
     st.info("DBを更新しました")
 
     corrections_path = os.path.join(WORKSPACE_DIR, "corrections.jsonl")
@@ -64,6 +64,7 @@ def load_review_items():
                     "extract_path": extract_path,
                     "crops_dir": crops_dir,
                     "data": data,
+                    "result_id": info.get("result_id"),
                 }
                 items.append(item)
     return items

--- a/src/core/db_manager.py
+++ b/src/core/db_manager.py
@@ -93,16 +93,18 @@ class DBManager:
         rows = cur.fetchall()
         return [dict(r) for r in rows]
 
-    def update_result_by_text(self, roi_name: str, old_text: str, new_text: str) -> None:
-        """Update final_text and corrected flag for a given ROI using previous text."""
+    def update_result_by_text(
+        self, result_id: int, roi_name: str, old_text: str, new_text: str
+    ) -> None:
+        """Update a specific result's text using its identifier and previous text."""
         cur = self.conn.cursor()
         cur.execute(
             """
             UPDATE ocr_results
             SET final_text = ?, corrected_by_user = 1
-            WHERE roi_name = ? AND final_text = ?
+            WHERE result_id = ? AND roi_name = ? AND final_text = ?
             """,
-            (new_text, roi_name, old_text),
+            (new_text, result_id, roi_name, old_text),
         )
         self.conn.commit()
 

--- a/tests/test_review_updates.py
+++ b/tests/test_review_updates.py
@@ -23,7 +23,7 @@ def test_save_correction_updates_db_and_template(tmp_path):
     crops = workspace_doc / 'crops'
     crops.mkdir(parents=True, exist_ok=True)
     extract = workspace_doc / 'extract.json'
-    data = {'field': {'text': 'OLD', 'needs_human': True, 'source_image': 'P1_field.png'}}
+    data = {'field': {'text': 'OLD', 'needs_human': True, 'source_image': 'P1_field.png', 'result_id': 1}}
     with open(extract, 'w', encoding='utf-8') as f:
         json.dump(data, f, ensure_ascii=False)
     with open(workspace_doc / 'template.json', 'w', encoding='utf-8') as f:
@@ -52,6 +52,7 @@ def test_save_correction_updates_db_and_template(tmp_path):
         'extract_path': str(extract),
         'crops_dir': str(crops),
         'data': data,
+        'result_id': 1,
     }
 
     review = load_review_module()


### PR DESCRIPTION
## Summary
- handle result_id in review items
- update review save to send result identifier to DB
- extend DB manager to update using result_id

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688decaecbd88333a75e4ea2ce4c82c8