### PR TITLE
feat(core): persist result ids in OCR outputs

### DIFF
--- a/src/core/db_manager.py
+++ b/src/core/db_manager.py
@@ -64,7 +64,7 @@ class DBManager:
         confidence_score: float | None = None,
         status: str | None = None,
         corrected_by_user: bool = False,
-    ) -> None:
+    ) -> int:
         cur = self.conn.cursor()
         cur.execute(
             """
@@ -86,6 +86,7 @@ class DBManager:
             ),
         )
         self.conn.commit()
+        return int(cur.lastrowid)
 
     def fetch_results(self, job_id: int) -> Iterable[Dict[str, Any]]:
         cur = self.conn.cursor()

--- a/src/core/ocr_agent.py
+++ b/src/core/ocr_agent.py
@@ -109,7 +109,7 @@ class OcrAgent:
         if job_id is None:
             job_id = self.db.create_job(template_data.get("name", ""), now.isoformat())
         for roi_name, info in results.items():
-            self.db.add_result(
+            result_id = self.db.add_result(
                 job_id,
                 image_name,
                 roi_name,
@@ -119,5 +119,11 @@ class OcrAgent:
                 confidence_score=info["confidence"],
                 status=info.get("confidence_level"),
             )
+            info["result_id"] = result_id
+
+        # Overwrite extract.json with result IDs included
+        extract_path = workspace_dir / "extract.json"
+        with extract_path.open("w", encoding="utf-8") as f:
+            json.dump(results, f, ensure_ascii=False, indent=4)
 
         return results, str(workspace_dir)

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -7,10 +7,11 @@ def test_db_manager(tmp_path):
     db.initialize()
 
     job_id = db.create_job("invoice", "2025-01-01T00:00:00")
-    db.add_result(job_id, "img.png", "zip_code", text_mini="1234567")
+    result_id = db.add_result(job_id, "img.png", "zip_code", text_mini="1234567")
 
     results = list(db.fetch_results(job_id))
     assert len(results) == 1
     assert results[0]["text_mini"] == "1234567"
+    assert results[0]["result_id"] == result_id
 
     db.close()

--- a/tests/test_ocr_agent.py
+++ b/tests/test_ocr_agent.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import json
 
 import cv2
 import numpy as np
@@ -31,6 +32,7 @@ def test_ocr_agent_process_document(tmp_path):
     )
 
     assert "field" in results
+    assert results["field"]["result_id"] == 1
     assert Path(workspace).exists()
     db_results = db.fetch_results(1)
     assert db_results[0]["roi_name"] == "field"
@@ -38,6 +40,9 @@ def test_ocr_agent_process_document(tmp_path):
     assert db_results[0]["text_nano"] == "ダミーテキスト(10x10)"
     assert db_results[0]["confidence_score"] == 1.0
     assert db_results[0]["status"] == "high"
+    with open(Path(workspace) / "extract.json", "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["field"]["result_id"] == 1
     db.close()
 
 
@@ -68,4 +73,5 @@ def test_ocr_agent_multiple_images_single_job(tmp_path):
     db_results = db.fetch_results(job_id)
     assert len(db_results) == 2
     assert {r["image_name"] for r in db_results} == {"a.png", "b.png"}
+    assert {r["result_id"] for r in db_results} == {1, 2}
     db.close()


### PR DESCRIPTION
## Summary
- return SQLite lastrowid from `DBManager.add_result`
- annotate each OCR result with its `result_id` and rewrite `extract.json`
- verify review loader reads `result_id`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688df21bbb30833381a1ea9a75a31512