### PR TITLE
feat: persist template image path for ROI alignment

### DIFF
--- a/src/app/0_Template_Editor.py
+++ b/src/app/0_Template_Editor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+from pathlib import Path
+
 from PIL import Image
 import streamlit as st
 from streamlit_drawable_canvas import st_canvas
@@ -112,10 +114,17 @@ def main() -> None:
             keywords = [
                 kw.strip() for kw in keywords_text.split(",") if kw.strip()
             ]
+
+            # save uploaded reference image
+            suffix = Path(uploaded.name).suffix or ".png"
+            image_path = manager.template_dir / f"{template_name}{suffix}"
+            image.save(image_path)
+
             data = {
                 "name": template_name,
                 "keywords": keywords,
                 "rois": roi_definitions,
+                "template_image_path": str(image_path),
                 # corrections are stored as a list for forward compatibility
                 "corrections": [],
             }

--- a/src/core/ocr_agent.py
+++ b/src/core/ocr_agent.py
@@ -81,9 +81,7 @@ class OcrAgent:
         # Preprocess image and align ROIs
         corrected_image = preprocess.correct_skew(image)
 
-        template_path = template_data.get("template_image") or template_data.get(
-            "template_image_path"
-        )
+        template_path = template_data.get("template_image_path")
         if template_path and Path(template_path).exists():
             template_img = cv2.imread(str(template_path))
             aligned_rois = preprocess.align_rois(template_img, corrected_image, rois)

--- a/src/core/template_manager.py
+++ b/src/core/template_manager.py
@@ -35,12 +35,16 @@ class TemplateManager:
     def save(self, name: str, data: Dict[str, Any]) -> None:
         """Save template data to a JSON file.
 
-        The ``keywords`` field is normalised to always be present as a list to
-        simplify downstream consumption."""
+        Any additional fields are preserved to allow forward compatible
+        extensions such as ``template_image_path``.  The ``keywords`` field is
+        normalised to always be present as a list to simplify downstream
+        consumption.
+        """
         path = self.template_dir / f"{name}.json"
-        data.setdefault("keywords", [])
+        data_to_save = dict(data)
+        data_to_save.setdefault("keywords", [])
         with path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
+            json.dump(data_to_save, f, ensure_ascii=False, indent=2)
 
     def get_keywords(self, name: str) -> List[str]:
         """Return the list of detection keywords for a template.

--- a/tests/test_roi_alignment.py
+++ b/tests/test_roi_alignment.py
@@ -36,7 +36,7 @@ def test_roi_alignment_with_shift(tmp_path, monkeypatch):
 
     template_data = {
         "name": "test",
-        "template_image": str(template_path),
+        "template_image_path": str(template_path),
         "rois": {"field": {"box": [40, 60, 80, 40]}},
     }
 

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -7,6 +7,7 @@ def test_template_manager_roundtrip(tmp_path):
         "name": "tmp",
         "keywords": ["a", "b"],
         "rois": {"field": {"box": [0, 0, 10, 10]}},
+        "template_image_path": "templates/tmp.png",
     }
     manager.save("sample", data)
 


### PR DESCRIPTION
## Summary
- save uploaded template reference images and record their path in template data
- allow TemplateManager to preserve arbitrary fields like `template_image_path`
- load `template_image_path` in OCR agent and feed it to ROI alignment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688df3db1874833393102b57f7a1294d