### PR TITLE
feat: apply correction mappings to OCR results

### DIFF
--- a/src/core/ocr_agent.py
+++ b/src/core/ocr_agent.py
@@ -95,11 +95,13 @@ class OcrAgent:
             cv2.imwrite(str(crops_dir / filename), cropped)
 
         # Execute OCR
+        corrections = template_data.get("corrections", [])
         processor = OCRProcessor(
             ocr_engine,
             str(workspace_dir),
             validator_engine=validator_engine,
             rois=aligned_rois,
+            corrections=corrections,
         )
         results = asyncio.run(processor.process_all())
 


### PR DESCRIPTION
## Summary
- allow OCRProcessor to replace known misreads using correction mappings
- pass template-level corrections through OcrAgent to OCRProcessor
- verify corrections flow with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688df5792af48333a0ec443b38274a9b