### PR TITLE
feat(main-ocr): support zip uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ streamlit run src/app/main.py
 ```
 On Windows you can run `run.bat` which executes the same command.
 
-This will launch a local web server where you can upload an image and a YAML file that defines the ROIs.
+This will launch a local web server where you can upload image files or a ZIP archive/folder containing images along with a YAML file that defines the ROIs. ZIP archives are extracted to a temporary directory and all contained images are processed sequentially.
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- allow Main OCR page to accept ZIP archives or folders and expand them to a temporary directory
- process extracted files with existing loop and progress bar
- document ZIP/folder upload option in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688df86d99c4833380604a021eb8f38f