### PR TITLE
fix: handle OpenAI API errors in OCR bridge

### DIFF
--- a/src/core/ocr_bridge.py
+++ b/src/core/ocr_bridge.py
@@ -68,6 +68,11 @@ class GPT4oMiniVisionOCR(BaseOCR):
                     headers=headers,
                     json=payload,
                 ) as resp:
+                    if resp.status != 200:
+                        error_text = await resp.text()
+                        raise RuntimeError(
+                            f"OpenAI API request failed ({resp.status}): {error_text}"
+                        )
                     data = await resp.json()
             text = data["choices"][0]["message"]["content"].strip()
             confidence = 0.99
@@ -115,6 +120,11 @@ class GPT4oNanoVisionOCR(BaseOCR):
                     headers=headers,
                     json=payload,
                 ) as resp:
+                    if resp.status != 200:
+                        error_text = await resp.text()
+                        raise RuntimeError(
+                            f"OpenAI API request failed ({resp.status}): {error_text}"
+                        )
                     data = await resp.json()
             text = data["choices"][0]["message"]["content"].strip()
             confidence = 0.99

--- a/tests/test_ocr_bridge.py
+++ b/tests/test_ocr_bridge.py
@@ -47,6 +47,8 @@ def test_gpt4o_mini_vision_ocr_integration(sample_text_image):
     assert confidence > 0.0
 
 class MockResponse:
+    status = 200
+
     async def __aenter__(self):
         return self
 
@@ -55,6 +57,9 @@ class MockResponse:
 
     async def json(self):
         return {"choices": [{"message": {"content": "モックされたOCR結果"}}]}
+
+    async def text(self):
+        return ""
 
 
 @patch("aiohttp.ClientSession.post", return_value=MockResponse())


### PR DESCRIPTION
## Summary
- raise an error when OpenAI chat completion requests return non-200 status codes
- test mock updated for new response handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e05152c508333b5444a498e3b8483