### PR TITLE
build: rely on package imports for OCR entry point

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -2,6 +2,9 @@
 REM Ensure the script runs from its own directory for portability
 cd /d "%~dp0"
 
+REM Add src to PYTHONPATH for package imports
+set PYTHONPATH=%~dp0src;%PYTHONPATH%
+
 REM Launch AIOCR using Streamlit
 poetry run streamlit run src/app/main.py %*
 

--- a/src/app/1_Main_OCR.py
+++ b/src/app/1_Main_OCR.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import sys
 import tempfile
 import zipfile
 import shutil
@@ -11,9 +10,6 @@ from typing import Dict, List
 import cv2
 import numpy as np
 import streamlit as st
-
-# Ensure src directory is on the import path when executed directly
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.ocr_bridge import DummyOCR, GPT4oMiniVisionOCR, GPT4oNanoVisionOCR
 from app.cache_utils import get_template_manager, get_db_manager, list_templates


### PR DESCRIPTION
## Summary
- remove sys.path hacks and use package imports in 1_Main_OCR
- add PYTHONPATH setup in run.bat for installable package layout

## Testing
- `PYTHONPATH=src pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688e06400dec8333843e5dbbe3d55f25