### PR TITLE
refactor(db): simplify result update API

### DIFF
--- a/src/app/pages/1_Review.py
+++ b/src/app/pages/1_Review.py
@@ -17,7 +17,7 @@ def save_correction(item: dict, new_text: str, add_dict: bool) -> None:
         json.dump(item["data"], f, ensure_ascii=False, indent=4)
 
     db = get_db_manager()
-    db.update_result_by_text(item["result_id"], item["key"], item["text"], new_text)
+    db.update_result(item["result_id"], new_text)
     st.info("DBを更新しました")
 
     corrections_path = os.path.join(WORKSPACE_DIR, "corrections.jsonl")

--- a/src/core/db_manager.py
+++ b/src/core/db_manager.py
@@ -94,18 +94,24 @@ class DBManager:
         rows = cur.fetchall()
         return [dict(r) for r in rows]
 
-    def update_result_by_text(
-        self, result_id: int, roi_name: str, old_text: str, new_text: str
-    ) -> None:
-        """Update a specific result's text using its identifier and previous text."""
+    def update_result(self, result_id: int, new_text: str) -> None:
+        """Update the text of a result and mark it as corrected.
+
+        Parameters
+        ----------
+        result_id:
+            Primary key of the ``ocr_results`` row to update.
+        new_text:
+            Replacement text supplied by the human reviewer.
+        """
         cur = self.conn.cursor()
         cur.execute(
             """
             UPDATE ocr_results
             SET final_text = ?, corrected_by_user = 1
-            WHERE result_id = ? AND roi_name = ? AND final_text = ?
+            WHERE result_id = ?
             """,
-            (new_text, result_id, roi_name, old_text),
+            (new_text, result_id),
         )
         self.conn.commit()
 

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -7,11 +7,12 @@ def test_db_manager(tmp_path):
     db.initialize()
 
     job_id = db.create_job("invoice", "2025-01-01T00:00:00")
-    result_id = db.add_result(job_id, "img.png", "zip_code", text_mini="1234567")
+    result_id = db.add_result(job_id, "img.png", "zip_code", final_text="OLD")
 
+    db.update_result(result_id, "NEW")
     results = list(db.fetch_results(job_id))
     assert len(results) == 1
-    assert results[0]["text_mini"] == "1234567"
-    assert results[0]["result_id"] == result_id
+    assert results[0]["final_text"] == "NEW"
+    assert results[0]["corrected_by_user"] == 1
 
     db.close()


### PR DESCRIPTION
## Summary
- replace `update_result_by_text` with `update_result` to update OCR results by ID
- streamline review page to use new DB API
- adjust unit tests for updated DB interface

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e12f8ac7c8333bbdbf305770f361f